### PR TITLE
fixed conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ You can customize a cell using dynamic slots like this:
         {"key": "details", "label": "Details", "searchable": true},
         {"key": "status", "label": "User status", "searchable": true},
     ],
-
     "rows": [
         {"date": "10.11.2023", "details": "Some details", "status": "Active"},
         {"date": "27.12.2023", "details": "Details", "status": "Inactive"},

--- a/src/components/TableData.vue
+++ b/src/components/TableData.vue
@@ -64,7 +64,7 @@ const filteredRows = computed(() => {
     return managesLoadedData.getAllData().filter(row => {
         return Object.keys(searchTerms.value).every(key => {
             let searchTerm = helpers.cleanTerm(searchTerms.value[key]);
-            let columnValue = helpers.cleanTerm(row[key] ?? '');
+            let columnValue = helpers.cleanTerm(helpers.getDataFromKey(row, key) ?? '');
 
             return columnValue.toLowerCase().includes(searchTerm.toLowerCase());
         });
@@ -260,12 +260,13 @@ onMounted(() => setTableHeight());
                 <tr v-for="row in filteredRows" @click="handleRowClick(row)">
                     <td v-for="column in visibleColumns" :class="cellStyle(column.isNumeric, row[column.key])">
                         <slot
+
                             :name="`cell.${column.key}`"
-                            :value="row[column.key]"
+                            :value="helpers.getDataFromKey(row, column.key)"
                             :column="column"
                             :row="row"
                             :helpers="helpers"
-                        >{{ column.isNumeric ? helpers.formatNumericValue(row[column.key]) : row[column.key] }}</slot>
+                        >{{ column.isNumeric ? helpers.formatNumericValue(helpers.getDataFromKey(row, column.key)) : helpers.getDataFromKey(row, column.key) }}</slot>
                     </td>
                 </tr>
 

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -52,5 +52,14 @@ export default {
         term = term.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 
         return term.replace(/[^0-9a-z]/gi, '').toLowerCase();
+    },
+
+    getDataFromKey(row, key) {
+        if (!key.includes('.')) return row[key];
+
+        return key.split('.')
+            .reduce((currentObject, _key) => {
+                return currentObject ? currentObject[_key] : undefined;
+            }, row)
     }
 };


### PR DESCRIPTION
This PR adds option to load a value from a nested object.
In headers objects we can have a key like this: 
 `{'key': 'person.name', 'label': 'person name', 'searchable': true},`

And in rows we can have an object like this: 

```
{'date': '22.05.1997', 'details': 'New details', 'status': 'Active', person: {
            name: 'cosmin'
        }}
```
